### PR TITLE
fix: duplicate javax in pom result in gke fail

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,14 +118,6 @@
             <version>3.8.0</version>
         </dependency>
 
-        <!-- Servlet API -->
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-            <version>2.5</version>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Main Guacamole library -->
         <dependency>
             <groupId>org.apache.guacamole</groupId>
@@ -133,6 +125,7 @@
             <version>1.5.1</version>
             <scope>compile</scope>
         </dependency>
+
         <!-- GCP Compute -->
         <dependency>
             <groupId>com.google.cloud</groupId>


### PR DESCRIPTION
Javax Servlet is a provided dependency as part of the Apache Guacamole package. As such, the duplicated mention of the Javax Servlet package in the pom.xml will result in two copies of the same jar file being in path. Hence, GKE docker container will fail to run due to this conflict.